### PR TITLE
chore(github/workflows): Add PR checks workflow for coverage reporting

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -1,0 +1,24 @@
+name: PR checks
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, ready_for_review]
+concurrency:
+  group: '${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}'
+  cancel-in-progress: true
+jobs:
+  coverage:
+    name: Codecov
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.23.1'
+      - name: Run coverage
+        run: go test ./... -race -coverprofile=coverage.out -covermode=atomic
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v3
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
This commit introduces a new GitHub Actions workflow that runs on pull request events. 
It includes steps for checking out the code, setting up the Go environment, running tests with coverage, and uploading the coverage report to Codecov.